### PR TITLE
URL encoding for connection string

### DIFF
--- a/Sources/PostgresSessions.swift
+++ b/Sources/PostgresSessions.swift
@@ -23,7 +23,7 @@ public struct PostgresSessionConnector {
 	private init(){}
 
 	public static func connectionString() -> String {
-		return "postgresql://\(PostgresSessionConnector.username):\(PostgresSessionConnector.password)@\(PostgresSessionConnector.host):\(PostgresSessionConnector.port)/\(PostgresSessionConnector.database)"
+		return "postgresql://\(PostgresSessionConnector.username.stringByEncodingURL):\(PostgresSessionConnector.password.stringByEncodingURL)@\(PostgresSessionConnector.host.stringByEncodingURL):\(PostgresSessionConnector.port)/\(PostgresSessionConnector.database.stringByEncodingURL)"
 	}
 
 }


### PR DESCRIPTION
Fixes connection failure when using special characters in usernames/passwords, etc.