### PR TITLE
Prevent propagation of OPTION request

### DIFF
--- a/Sources/PostgresSessionDriver.swift
+++ b/Sources/PostgresSessionDriver.swift
@@ -95,6 +95,9 @@ extension SessionPostgresFilter: HTTPRequestFilter {
 				}
 
 				CORSheaders.make(request, response)
+				if request.method == .options {
+					callback(HTTPRequestFilterResult.halt(request, response))
+				}
 			}
 		}
 		callback(HTTPRequestFilterResult.continue(request, response))


### PR DESCRIPTION
Right now preflight OPTION request made by browser is passed down to next request filter. This can lead to unexpected behavior. Browser expects a 200 OK response if CORS is enabled by the server.

With this fix, OPTION requests are terminated with session request filter if CORS is enabled.